### PR TITLE
Add glass roof probability raster

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,10 @@ Currently it is using rerun.io to visualise the result. You need to install the 
 
 ## Installation
 
-clone this repository. Then
+First you need to install:
+CGAL, GDAL, PROJ, GEOS, LASlib, nlohmann-json
+
+Then clone this repository and:
 
 ```
 cd roofer-dev
@@ -35,7 +38,6 @@ cmake ..
 cmake --build . --parallel 10
 ```
 
-This assumes you have CGAL, GDAL, PROJ, GEOS, LASlib  preinstalled on your system
 
 ## Run with test-data
 Assuming you build roofer successfully. Unzip the contents of [wippolder.zip](https://data.3dgi.xyz/geoflow-test-data/wippolder.zip) into `test-data`, then
@@ -43,5 +45,5 @@ Assuming you build roofer successfully. Unzip the contents of [wippolder.zip](ht
 ```
 cd test-data
 ../build/apps/crop -c crop_config.toml
-../build/apps/reconstruct --verbose
+../build/apps/reconstruct --verbose --config output/wippolder/objects/503100000000296/config_.toml
 ```

--- a/src/datastructures/Raster.cpp
+++ b/src/datastructures/Raster.cpp
@@ -59,8 +59,11 @@ namespace RasterTools {
   void Raster::prefill_arrays(alg a){
   if (a==MIN)
     noDataVal_ = std::numeric_limits<float>::max();
-  else
+  else if (a==MAX)
     noDataVal_ = -std::numeric_limits<float>::max();
+  else {
+    noDataVal_ = 0;
+  }
     
   std::fill(vals_->begin(), vals_->end(), noDataVal_);
   // std::fill(counts_->begin(), counts_->end(), 0);
@@ -74,6 +77,13 @@ namespace RasterTools {
     } else if (a==MAX) {
       max(x,y,z);
     }
+    return first;
+  }
+
+  bool Raster::add_value(double x, double y, double val)
+  {
+    bool first = (*vals_)[getLinearCoord(x,y)]==noDataVal_;
+    add(x,y,val);
     return first;
   }
   bool Raster::check_point(double x, double y)
@@ -103,6 +113,12 @@ namespace RasterTools {
   {
     size_t c = getLinearCoord(x,y);
     if ((*vals_)[c]<val) (*vals_)[c] = val;
+  }
+
+  inline void Raster::add(double &x, double &y, double &val)
+  {
+    size_t c = getLinearCoord(x,y);
+    (*vals_)[c] = (*vals_)[c]+val;
   }
 
   // inline void Raster::cnt(double &x, double &y)

--- a/src/datastructures/Raster.hpp
+++ b/src/datastructures/Raster.hpp
@@ -30,7 +30,7 @@
 // #include <cpl_conv.h>
 // #include <ogr_spatialref.h>
 namespace RasterTools {
-    enum alg {MIN,MAX};
+    enum alg {MIN,MAX,ZERO};
     class Raster
     {
     public:
@@ -41,15 +41,53 @@ namespace RasterTools {
         void operator=(const Raster& r);
         Raster(){};
         ~Raster(){};
+        /**
+         * Prefills the raster array based on the specified method.
+         * @param[in] a The method to be used for prefilling the raster arrays: MIN, MAX or ZERO.
+         */
         void prefill_arrays(alg a);
         bool add_point(double x, double y, double z, alg a);
+        /**
+         * Adds a value to the raster at the specified x and y coordinates.
+         * @param[in] x x coordinate of the point
+         * @param[in] y y coordinate of the point
+         * @param[in] val value to be added
+         * @return True if the value was added, false if the point is outside the raster.
+         */
+        bool add_value(double x, double y, double val);
+        /**
+         * Checks if the point is within the raster.
+         * @param[in] x x coordinate of the point
+         * @param[in] y y coordinate of the point
+         * @return True if the point is within the raster, false otherwise.
+         */
         bool check_point(double x, double y);
-        void add_raster(double x, double y, double z, alg a);
+        //void add_raster(double x, double y, double z, alg a); // this seems unused. Should it be removed?
+        
+        /**
+         * Gets the row number for the given x and y coordinates.
+         * @param[in] x x coordinate of the point
+         * @param[in] y y coordinate of the point
+         * @return The row number.
+         */
         size_t getRow(double x, double y) const;
+        /**
+         * Gets the col number for the given x and y coordinates.
+         * @param[in] x x coordinate of the point
+         * @param[in] y y coordinate of the point
+         * @return The col number.
+         */
         size_t getCol(double x, double y) const;
         size_t getLinearCoord(double x, double y) const;
         size_t getLinearCoord(size_t r, size_t c) const;
         std::array<double,2> getColRowCoord(double x, double y) const;
+        /**
+         * Get the 3D point at the center of the input raster cell.
+         *
+         * @param[in] col the column of the cell
+         * @param[in] row the row of the cell
+         * @return the 3D point in the center of the cell
+         */
         point3d getPointFromRasterCoords(size_t col, size_t row) const;
         double getNoDataVal() {return noDataVal_;};
         double sample(double &x, double &y);
@@ -147,6 +185,13 @@ namespace RasterTools {
         void avg(double &x, double &y, double &val);
         void min(double &x, double &y, double &val);
         void max(double &x, double &y, double &val);
+        /**
+         * Adds the input value to the value at the given coordinate of the raster.
+         * @param[in] val value to be added
+         * @param[in] x x coordinate
+         * @param[in] y y coordinate
+        */
+        void add(double &x, double &y, double &val);
         // void cnt(double &x, double &y);
         // OGRSpatialReference oSRS;
     };


### PR DESCRIPTION
This is how the probabilities of a buuilding being a greenhouse look like:

<img width="95" alt="image" src="https://github.com/3DGI/roofer-dev/assets/94386515/27722f90-98cd-41a8-b834-45f56d679f0e">

<img width="564" alt="image" src="https://github.com/3DGI/roofer-dev/assets/94386515/51dd74b8-f888-48a1-aefb-6e98702cea17">

Example of multiple buildings, the probability of most cells seems to be 1 (which will later be classified as non-glass-roof):

<img width="531" alt="image" src="https://github.com/3DGI/roofer-dev/assets/94386515/5b4b9f56-7873-4c67-af65-4d769aaa94b0">

I didn;t find any glass roof examples in the test dataset but I can use this to create rasters for my test region. 